### PR TITLE
ENH: Build ITK Video BridgeOpenCV as an external module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ if(NOT DEFINED opencv_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     set(git_protocol "git")
   endif()
 
-  set(EP_SOURCE_DIR ${CMAKE_SOURCE_DIR}/${proj}-source)
+  # check out to the binary dir to keep the git checkout clean
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}-source)
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR})
 
@@ -92,6 +93,55 @@ ExternalProject_Message(${proj} "OPENCV_LIBRARY:${OPENCV_LIBRARY}")
 if(OPENCV_ROOT)
   ExternalProject_Message(${proj} "OPENCV_ROOT:${OPENCV_ROOT}")
 endif()
+
+#-----------------------------------------------------------------------------
+# Build the ITK OpenCV bridge, pointing it to Slicer's ITK and this build
+# of OpenCV
+set(bridgeproj bridgeopencv)
+
+# Dependencies
+set(${bridgeproj}_DEPENDENCIES "")
+ExternalProject_Include_Dependencies(${bridgeproj} PROJECT_VAR bridgeproj DEPENDS_VAR ${bridgeproj}_DEPENDENCIES)
+
+# don't allow using the system ITK, use the Slicer one
+set(BRIDGE_BINARY_DIR ${CMAKE_BINARY_DIR}/${bridgeproj}-build)
+set(BRIDGE_INSTALL_DIR ${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR})
+
+set(ITK_SOURCE_DIR ${ITK_DIR}/../ITKv4)
+set(ITK_BRIDGE_SOURCE_DIR ${ITK_SOURCE_DIR}/Modules/Video/BridgeOpenCV)
+message(STATUS "ITK source dir set to ${ITK_SOURCE_DIR}")
+message(STATUS "ITK source dir set to ${ITK_BRIDGE_SOURCE_DIR}")
+mark_as_superbuild(
+  VARS ITK_BRIDGE_SOURCE_DIR:PATH
+  LABELS "FIND_PACKAGE"
+  )
+# let cmake find ITKExternal
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${ITK_SOURCE_DIR}/CMake")
+
+ExternalProject_Add(${bridgeproj}
+  ${${bridgeproj}_EP_ARGS}
+  DEPENDS ${proj}
+  # build from Slicer's ITK into the extension's ITK build dir
+  SOURCE_DIR ${ITK_BRIDGE_SOURCE_DIR}
+  BINARY_DIR ${BRIDGE_BINARY_DIR}
+  INSTALL_DIR ${BRIDGE_INSTALL_DIR}
+  CMAKE_CACHE_ARGS
+    -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+    -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+    -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+    -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+    -DCMAKE_BUILD_TYPE:STRING=Debug
+    # to find ITKConfig.cmake
+    -DITK_DIR:PATH=${ITK_DIR}
+    # OpenCV
+    -DOpenCV_INCLUDE_DIRS:STRING=${OPENCV_INCLUDE_DIR};${OPENCV_INCLUDE_DIR}/opencv
+    -DOpenCV_LIB_DIR:PATH=${opencv_DIR}/lib
+    -DOpenCV_DIR:PATH=${opencv_DIR}/share/OpenCV
+    -DOpenCV_LIB_DIR_DBG:PATH=${opencv_DIR}/lib
+    -DOpenCV_LIB_DIR_OPT:PATH=${opencv_DIR}/lib
+    -DOpenCV_LIBS:STRING=opencv_core;opencv_videoio;opencv_imgproc
+    -DCMAKE_INSTALL_PREFIX:PATH=${BRIDGE_INSTALL_DIR}
+)
 
 #-----------------------------------------------------------------------------
 # Extension modules

--- a/OpenCV/CMakeLists.txt
+++ b/OpenCV/CMakeLists.txt
@@ -6,14 +6,21 @@ set(MODULE_TITLE ${MODULE_NAME})
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
 #-----------------------------------------------------------------------------
+add_subdirectory(Logic)
 # add_subdirectory(Widgets)
 
 #-----------------------------------------------------------------------------
 set(MODULE_EXPORT_DIRECTIVE "Q_SLICER_QTMODULES_${MODULE_NAME_UPPER}_EXPORT")
 
 # Current_{source,binary} and Slicer_{Libs,Base} already included
+set(MODULE_INCLUDE_DIRECTORY_BASE ${CMAKE_CURRENT_BINARY_DIR}/../${Slicer_QTLOADABLEMODULES_LIB_DIR}/include)
+# needs the base as well as subdirs due to how files are included in opencv and ITK
 set(MODULE_INCLUDE_DIRECTORIES
-  ${CMAKE_CURRENT_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/Logic
+  ${CMAKE_CURRENT_BINARY_DIR}/Logic
+  ${MODULE_INCLUDE_DIRECTORY_BASE}
+  ${MODULE_INCLUDE_DIRECTORY_BASE}/opencv
+  ${MODULE_INCLUDE_DIRECTORY_BASE}/ITK-4.8
   )
 
 set(MODULE_SRCS
@@ -28,7 +35,13 @@ set(MODULE_MOC_SRCS
 set(MODULE_UI_SRCS
   )
 
+# point to the opencv libraries
+set(OPENCV_LIBRARY_PATH ${CMAKE_CURRENT_BINARY_DIR}/../${Slicer_QTLOADABLEMODULES_LIB_DIR}/lib)
+MESSAGE(STATUS "OPENCV_LIBRARY_PATH = ${OPENCV_LIBRARY_PATH}")
+link_directories(${OPENCV_LIBRARY_PATH})
+
 set(MODULE_TARGET_LIBRARIES
+  vtkSlicer${MODULE_NAME}ModuleLogic
   )
 
 set(TARGET_LINK_LIBRARIES

--- a/OpenCV/Logic/CMakeLists.txt
+++ b/OpenCV/Logic/CMakeLists.txt
@@ -1,0 +1,39 @@
+project(vtkSlicer${MODULE_NAME}ModuleLogic)
+
+set(KIT ${PROJECT_NAME})
+
+set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_LOGIC_EXPORT")
+
+set(MODULE_INCLUDE_DIRECTORY_BASE ${CMAKE_CURRENT_BINARY_DIR}/../../${Slicer_QTLOADABLEMODULES_LIB_DIR}/include)
+set(${KIT}_INCLUDE_DIRECTORIES
+  ${MODULE_INCLUDE_DIRECTORY_BASE}
+  ${MODULE_INCLUDE_DIRECTORY_BASE}/opencv
+  ${MODULE_INCLUDE_DIRECTORY_BASE}/ITK-4.8
+  )
+MESSAGE(STATUS "${KIT} include dirs = ${${KIT}_INCLUDE_DIRECTORIES}")
+
+set(${KIT}_SRCS
+  vtkSlicer${MODULE_NAME}Logic.cxx
+  vtkSlicer${MODULE_NAME}Logic.h
+  )
+
+set(MODULE_TARGET_LIBRARY_BASE ${CMAKE_CURRENT_BINARY_DIR}/../../${Slicer_QTLOADABLEMODULES_LIB_DIR}/lib)
+MESSAGE(STATUS "Logic target library base = ${MODULE_TARGET_LIBRARY_BASE}")
+link_directories(${MODULE_TARGET_LIBRARY_BASE})
+
+set(${KIT}_TARGET_LIBRARIES
+  opencv_videoio
+  ITKVideoBridgeOpenCV-4.8.1
+#  ${ITKVideoBridgeOpenCV_LIBRARIES}
+#  ITKVideoBridgeOpenCV
+  )
+
+
+#-----------------------------------------------------------------------------
+SlicerMacroBuildModuleLogic(
+  NAME ${KIT}
+  EXPORT_DIRECTIVE ${${KIT}_EXPORT_DIRECTIVE}
+  INCLUDE_DIRECTORIES ${${KIT}_INCLUDE_DIRECTORIES}
+  SRCS ${${KIT}_SRCS}
+  TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
+  )

--- a/OpenCV/Logic/vtkSlicerOpenCVLogic.cxx
+++ b/OpenCV/Logic/vtkSlicerOpenCVLogic.cxx
@@ -1,0 +1,123 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// OpenCV Logic includes
+#include "vtkSlicerOpenCVLogic.h"
+
+// MRML includes
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkIntArray.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+// STD includes
+#include <cassert>
+#include <iostream>
+
+// OpenCV includes
+#include <cv.h>
+#include <highgui.h>
+
+// ITK includes
+#include <itkVideoIOFactory.h>
+#include <itkOpenCVVideoIOFactory.h>
+#include <itkOpenCVVideoIO.h>
+
+//----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkSlicerOpenCVLogic);
+
+//----------------------------------------------------------------------------
+vtkSlicerOpenCVLogic::vtkSlicerOpenCVLogic()
+{
+  std::cout << "Logic!" << std::endl;
+
+  // register the OpenCV ITK IO factory
+  itk::ObjectFactoryBase::RegisterFactory( itk::OpenCVVideoIOFactory::New() );
+  itk::OpenCVVideoIO *videoIO = itk::OpenCVVideoIO::New();
+
+  if (0)
+    {
+    // will cause a crash on start up without proper settings
+    std::cout << "Trying to create IO for reading from file..." << std::endl;
+    char *input = NULL;
+    itk::VideoIOBase::Pointer ioReadFile = itk::VideoIOFactory::CreateVideoIO(
+      itk::VideoIOFactory::ReadFileMode, input);
+    if (!ioReadFile)
+      {
+      std::cerr << "Did not create valid VideoIO for reading from file " << std::endl;
+      return;
+      }
+
+
+    itk::SizeValueType cameraNumber = 0;
+    // Use openCV to see if we can even try to open the camera
+    CvCapture* cameraCapture = cvCaptureFromCAM( cameraNumber );
+    if (cameraCapture == ITK_NULLPTR)
+      {
+      std::cerr << "Unable to create a camera to capture from" << std::endl;
+      return;
+      }
+    }
+
+}
+
+//----------------------------------------------------------------------------
+vtkSlicerOpenCVLogic::~vtkSlicerOpenCVLogic()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerOpenCVLogic::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerOpenCVLogic::SetMRMLSceneInternal(vtkMRMLScene * newScene)
+{
+  vtkNew<vtkIntArray> events;
+  events->InsertNextValue(vtkMRMLScene::NodeAddedEvent);
+  events->InsertNextValue(vtkMRMLScene::NodeRemovedEvent);
+  events->InsertNextValue(vtkMRMLScene::EndBatchProcessEvent);
+  this->SetAndObserveMRMLSceneEventsInternal(newScene, events.GetPointer());
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerOpenCVLogic::RegisterNodes()
+{
+  assert(this->GetMRMLScene() != 0);
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerOpenCVLogic::UpdateFromMRMLScene()
+{
+  assert(this->GetMRMLScene() != 0);
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerOpenCVLogic
+::OnMRMLSceneNodeAdded(vtkMRMLNode* vtkNotUsed(node))
+{
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerOpenCVLogic
+::OnMRMLSceneNodeRemoved(vtkMRMLNode* vtkNotUsed(node))
+{
+}

--- a/OpenCV/Logic/vtkSlicerOpenCVLogic.h
+++ b/OpenCV/Logic/vtkSlicerOpenCVLogic.h
@@ -1,0 +1,65 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// .NAME vtkSlicerOpenCVLogic - slicer logic class for OpenCV library
+// .SECTION Description
+// This class manages the logic associated with reading, saving,
+// and changing properties of the OpenCV library
+
+
+#ifndef __vtkSlicerOpenCVLogic_h
+#define __vtkSlicerOpenCVLogic_h
+
+// Slicer includes
+#include "vtkSlicerModuleLogic.h"
+
+// MRML includes
+
+// STD includes
+#include <cstdlib>
+
+#include "vtkSlicerOpenCVModuleLogicExport.h"
+
+
+/// \ingroup Slicer_QtModules_ExtensionTemplate
+class VTK_SLICER_OPENCV_MODULE_LOGIC_EXPORT vtkSlicerOpenCVLogic :
+  public vtkSlicerModuleLogic
+{
+public:
+
+  static vtkSlicerOpenCVLogic *New();
+  vtkTypeMacro(vtkSlicerOpenCVLogic, vtkSlicerModuleLogic);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+protected:
+  vtkSlicerOpenCVLogic();
+  virtual ~vtkSlicerOpenCVLogic();
+
+  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene);
+  /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
+  virtual void RegisterNodes();
+  virtual void UpdateFromMRMLScene();
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+
+private:
+
+  vtkSlicerOpenCVLogic(const vtkSlicerOpenCVLogic&); // Not implemented
+  void operator=(const vtkSlicerOpenCVLogic&); // Not implemented
+};
+
+#endif

--- a/OpenCV/qSlicerOpenCVModule.cxx
+++ b/OpenCV/qSlicerOpenCVModule.cxx
@@ -19,11 +19,13 @@
 #include <QtPlugin>
 
 // OpenCV Logic includes
-//#include <vtkSlicerOpenCVLogic.h>
+#include <vtkSlicerOpenCVLogic.h>
 
 // OpenCV includes
 #include "qSlicerOpenCVModule.h"
 //#include "qSlicerOpenCVModuleWidget.h"
+
+// ITK includes
 
 //-----------------------------------------------------------------------------
 Q_EXPORT_PLUGIN2(qSlicerOpenCVModule, qSlicerOpenCVModule);
@@ -62,7 +64,7 @@ qSlicerOpenCVModule::~qSlicerOpenCVModule()
 //-----------------------------------------------------------------------------
 QString qSlicerOpenCVModule::helpText() const
 {
-  return "This is a loadable module that can be bundled in an extension";
+  return "This is a loadable module that provides access to OpenCV";
 }
 
 //-----------------------------------------------------------------------------
@@ -113,5 +115,5 @@ qSlicerAbstractModuleRepresentation* qSlicerOpenCVModule
 //-----------------------------------------------------------------------------
 vtkMRMLAbstractLogic* qSlicerOpenCVModule::createLogic()
 {
-  return NULL;
+  return vtkSlicerOpenCVLogic::New();
 }


### PR DESCRIPTION
Point directly to the OpenCV bridge module in Slicer's ITK
source code directory and build it into the extension's build
directory. Relies on some new changes to ITK that will allow
it to build as an external module.

Add logic to the OpenCV module, use it to test registering the OpenCV IO factory,
linking properly to the ITK OpenCV bridge that is built as an external
module. Compile but don't run the bridge and OpenCV calls as they'll cause
a crash without proper settings.
