### PR TITLE
Prevent MacOSX 10.6 build error disable OpenCL. Fixes #17

### DIFF
--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -84,6 +84,8 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DBUILD_opencv_world:BOOL=OFF
       # Disable VTK: not used, and is causing problems
       -DWITH_VTK:BOOL=OFF
+      # Disable OpenCL: Initially disabled because of build errors on MacOSX 10.6 (See #17)
+      -DWITH_OPENCL:BOOL=OFF
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )


### PR DESCRIPTION
This commit allows the build to succeed and avoid the error
reported below. Since OpenCL is not required by SlicerOpenCV,
it can be disabled.

Error:

//----------------
[...]

```
                                                                                      ^
```

/Users/kitware/Dashboards/Experimental/SlicerOpenCV-Release/OpenCV-source/modules/core/src/ocl.cpp:3520:53: error: use of undeclared
      identifier 'CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE'
    return clGetKernelWorkGroupInfo(p->handle, dev, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE,
                                                    ^
/Users/kitware/Dashboards/Experimental/SlicerOpenCV-Release/OpenCV-source/modules/core/src/ocl.cpp:5004:28: error: use of undeclared
      identifier 'clEnqueueReadBufferRect'
                CV_Assert( clEnqueueReadBufferRect(q, (cl_mem)u->handle, CL_TRUE,
                           ^
/Users/kitware/Dashboards/Experimental/SlicerOpenCV-Release/OpenCV-source/modules/core/include/opencv2/core/base.hpp:410:33: note: expanded
      from macro 'CV_Assert'
                                ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
2 warnings and 20 errors generated.
//----------------
