### PR TITLE
COMP: disable Java

### DIFF
--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -86,8 +86,8 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DWITH_VTK:BOOL=OFF
       # Disable OpenCL: Initially disabled because of build errors on MacOSX 10.6 (See #17)
       -DWITH_OPENCL:BOOL=OFF
-      # Disable creating a fat java wrapper containing the whole OpenCV library
-      -DBUILD_FAT_JAVA_LIB:BOOL=OFF
+      # Disable find_package(Java) so that java wrapping is not done
+      -DCMAKE_DISABLE_FIND_PACKAGE_JAVA:BOOL=ON
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )


### PR DESCRIPTION
Use JC's suggestion to disable Java from being found rather than
just disabling the wrapping.

Issue #17
