### PR TITLE
Fix windows configuration properly setting OpenCV_DIR

### DIFF
--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -91,8 +91,10 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
-
-  set(OpenCV_DIR ${${proj}_INSTALL_DIR}/share/OpenCV)
+  set(OpenCV_DIR ${${proj}_INSTALL_DIR})
+  if(UNIX)
+    set(OpenCV_DIR ${${proj}_INSTALL_DIR}/share/OpenCV)
+  endif()
 else()
   # The project is provided using OpenCV_DIR, nevertheless since other projects
   # may depend on OpenCV, let's add an 'empty' one


### PR DESCRIPTION
This commit will fix the following error:

```
  Add the installation prefix of "OpenCV" to CMAKE_PREFIX_PATH or set
    "OpenCV_DIR" to a directory containing one of the above files.  If "OpenCV"
    provides a separate development package or SDK, be sure it has been
    installed.
  Call Stack (most recent call first):
    CMakeLists.txt:3 (include)
```
