### PR TITLE
BUG: Include VTK libraries in Logic module

### DIFF
--- a/SlicerOpenCV/Logic/CMakeLists.txt
+++ b/SlicerOpenCV/Logic/CMakeLists.txt
@@ -25,6 +25,7 @@ set(${KIT}_SRCS
 
 
 set(${KIT}_TARGET_LIBRARIES
+  ${VTK_LIBRARIES}
   ${OpenCV_LIBS}
   ${ITK_LIBRARIES}
   )


### PR DESCRIPTION
When SlicerOpenCV is packaged and installed, Slicer is showing various
errors related to the extension's Logic module. Most seem to be related to
VTK errors. Adding the VTK libraries to the list of target libraries explicitly,
following the example of the Chest Imaging Platform AirwayInspector extension
that was checked to work, this change results in a properly loaded
extension from the package file.

Issue #30
