### PR TITLE
Fix build error

### DIFF
--- a/SuperBuild/External_ITKVideoBridgeOpenCV.cmake
+++ b/SuperBuild/External_ITKVideoBridgeOpenCV.cmake
@@ -8,7 +8,7 @@ set(proj ITKVideoBridgeOpenCV)
 set(${proj}_DEPENDENCIES OpenCV)
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
-set(ITK_SOURCE_DIR ${ITK_DIR}/../ITKv4)
+set(ITK_SOURCE_DIR ${ITK_DIR}/../ITK)
 set(${proj}_SOURCE_DIR ${ITK_SOURCE_DIR}/Modules/Video/BridgeOpenCV)
 ExternalProject_Message(${proj} "ITK_SOURCE_DIR:${ITK_SOURCE_DIR}")
 ExternalProject_Message(${proj} "${proj}_SOURCE_DIR:${${proj}_SOURCE_DIR}")


### PR DESCRIPTION
ITK path changed from ITKv4 to ITK, updated the superbuild accordingly.

Fixes build error "CMake Error: The source directory "/home/ROBARTS/arankin/dashboard/Preview/Slicer-0-build/ITKv4/Modules/Video/BridgeOpenCV" does not appear to contain CMakeLists.txt."

