### PR TITLE
Enabling OpenCV build with python wrapping in Debug configuration

### DIFF
--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -26,13 +26,13 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
-    "https://github.com/opencv/opencv.git"
+    https://github.com/Slicer/opencv.git
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "3.4.6"
+    3.4.6_user_release_python
     QUIET
     )
 
@@ -42,6 +42,11 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   if(APPLE)
     # Workaround for OpenCV 3.2+ and OSX clang compiler issues
     list(APPEND ADDITIONAL_OPENCV_ARGS -DBUILD_PROTOBUF:BOOL=OFF)
+  endif()
+
+  option(SlicerOpenCV_FORCE_RELEASE_PYTHON "Force the OpenCV build to use a release python" OFF)
+  if(SlicerOpenCV_FORCE_RELEASE_PYTHON)
+    list(APPEND ADDITIONAL_OPENCV_ARGS -DOPENCV_PYTHON_EXTRA_DEFINITIONS:STRING=CV_RELEASE_PYTHON # Force OpenCV to build using release python even if this is a Debug build
   endif()
 
   option(SlicerOpenCV_USE_CUDA "Enable or disable the building of CUDA modules" OFF)
@@ -60,7 +65,6 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
           -DPYTHON3_NUMPY_INCLUDE_DIRS:PATH=${_numpy_location}/numpy/core/include
           )
   endif()
-
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"

--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -32,7 +32,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    3.4.6_user_release_python
+    c8098f6c4001fd1a3a8f599f959beb3833f737b6
     QUIET
     )
 
@@ -44,7 +44,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     list(APPEND ADDITIONAL_OPENCV_ARGS -DBUILD_PROTOBUF:BOOL=OFF)
   endif()
 
-  option(SlicerOpenCV_FORCE_RELEASE_PYTHON "Force the OpenCV build to use a release python" OFF)
+  option(SlicerOpenCV_FORCE_RELEASE_PYTHON "Force the OpenCV build to use a release python" ON)
   if(SlicerOpenCV_FORCE_RELEASE_PYTHON)
     list(APPEND ADDITIONAL_OPENCV_ARGS -DOPENCV_PYTHON_EXTRA_DEFINITIONS:STRING=CV_RELEASE_PYTHON # Force OpenCV to build using release python even if this is a Debug build
   endif()
@@ -65,6 +65,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
           -DPYTHON3_NUMPY_INCLUDE_DIRS:PATH=${_numpy_location}/numpy/core/include
           )
   endif()
+  
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"

--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -32,7 +32,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    c8098f6c4001fd1a3a8f599f959beb3833f737b6
+    c8098f6c4001fd1a3a8f599f959beb3833f737b6 # slicer-3.4.7-2019.07.25-4a7ca5a29
     QUIET
     )
 
@@ -42,11 +42,6 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   if(APPLE)
     # Workaround for OpenCV 3.2+ and OSX clang compiler issues
     list(APPEND ADDITIONAL_OPENCV_ARGS -DBUILD_PROTOBUF:BOOL=OFF)
-  endif()
-
-  option(SlicerOpenCV_FORCE_RELEASE_PYTHON "Force the OpenCV build to use a release python" ON)
-  if(SlicerOpenCV_FORCE_RELEASE_PYTHON)
-    list(APPEND ADDITIONAL_OPENCV_ARGS -DOPENCV_PYTHON_EXTRA_DEFINITIONS:STRING=CV_RELEASE_PYTHON # Force OpenCV to build using release python even if this is a Debug build
   endif()
 
   option(SlicerOpenCV_USE_CUDA "Enable or disable the building of CUDA modules" OFF)
@@ -125,6 +120,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DCMAKE_DISABLE_FIND_PACKAGE_JAVA:BOOL=ON
       # Add Python wrapping, use Slicer's python
       -DOPENCV_SKIP_PYTHON_LOADER:BOOL=ON
+      -DOPENCV_PYTHON_EXTRA_DEFINITIONS:STRING=CV_RELEASE_PYTHON
       -DPYTHON3_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}
       -DPYTHON3_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DPYTHON3_LIBRARY:FILEPATH=${PYTHON_LIBRARY}

--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -65,7 +65,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
           -DPYTHON3_NUMPY_INCLUDE_DIRS:PATH=${_numpy_location}/numpy/core/include
           )
   endif()
-  
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"


### PR DESCRIPTION
Affects MSVC Debug configuration

Enables python wrapping for Debug build using Slicer's release python