### PR TITLE
COMP: Fix of possible superbuild compilation error under Linux

### DIFF
--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -198,7 +198,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${pr
 
   set(OpenCV_DIR ${${proj}_INSTALL_DIR})
   if(UNIX)
-    set(OpenCV_DIR ${${proj}_INSTALL_DIR}/lib/cmake/opencv4/)
+    set(OpenCV_DIR ${${proj}_INSTALL_DIR}/lib64/cmake/opencv4/)
   endif()
 
   ExternalProject_GenerateProjectDescription_Step(${proj})

--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -188,6 +188,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${pr
 
       # Install directories
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+      -DCMAKE_INSTALL_LIBDIR:STRING=${Slicer_INSTALL_THIRDPARTY_LIB_DIR} # Skip default initialization by GNUInstallDirs CMake module
       -DPYTHON3_PACKAGES_PATH:PATH=${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${PYTHON_SITE_PACKAGES_SUBDIR}
 
       ${ADDITIONAL_OPENCV_ARGS}
@@ -198,7 +199,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${pr
 
   set(OpenCV_DIR ${${proj}_INSTALL_DIR})
   if(UNIX)
-    set(OpenCV_DIR ${${proj}_INSTALL_DIR}/lib64/cmake/opencv4/)
+    set(OpenCV_DIR ${${proj}_INSTALL_DIR}/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/cmake/opencv4/)
   endif()
 
   ExternalProject_GenerateProjectDescription_Step(${proj})


### PR DESCRIPTION
Dear developers,

I have a problem with a SuperBuild compilation. The OpenCV compiles without problem, but the SlicerOpenCV module can't find OpenCV cmake files if these files are installed in lib directory. Compilation ends without issues if cmake files are in lib64 directory.

If anyone uses SlicerOpenCV on Linux, can such PR be acceptable or it depends on CMAKE_INSTALL_LIBDIR of a particular distribution?
