### PR TITLE
COMP: Ensure the Slicer python executable and libs are systematically found

### DIFF
--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -146,9 +146,17 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${pr
       -DOPENCV_PYTHON_EXTRA_DEFINITIONS:STRING=CV_RELEASE_PYTHON # Specific to Slicer/opencv fork
 
       # Dependencies: Python
+      # - Options expected by the OpenCV custom CMake function "find_python()"
+      #   implemented in "cmake/OpenCVDetectPython.cmake"
       -DPYTHON3_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}
       -DPYTHON3_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DPYTHON3_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
+      # - Options expected by the FindPythonInterp and FindPythonLibs CMake built-in modules
+      #   indirectly used in the OpenCV custom CMake macro "find_host_package"
+      #   implemented in "cmake/OpenCVUtils.cmake" and used in "find_python()".
+      -DPYTHON_EXECUTABLE:PATH=${PYTHON_EXECUTABLE}
+      -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
+      -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
 
       # Dependencies: VTK
       -DVTK_DIR:PATH=${VTK_DIR}


### PR DESCRIPTION
This commit passes option expected by the `FindPythonInterp` and `FindPythonLibs` CMake built-in modules indirectly used in the OpenCV custom CMake macro `find_host_package` implemented in `cmake/OpenCVUtils.cmake` and used in  `find_python()`.

It should help address the following warning/error reported on `metroplex` (Linux) build machine:

```
-- Detected processor: x86_64
-- Found PythonInterp: /usr/bin/python2.7 (found suitable version "2.7.5", minimum required is "2.7") 
-- Could NOT find PythonLibs (missing: PYTHON_LIBRARIES PYTHON_INCLUDE_DIRS) (Required is exact version "2.7.5")
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named numpy.distutils
-- Found PythonInterp: /work/Preview/Slicer-0-build/python-install/bin/PythonSlicer (found suitable version "3.9.10", minimum required is "3.2") 
<string>:1: DeprecationWarning: 

  `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
  of the deprecation of `distutils` itself. It will be removed for
  Python >= 3.12. For older Python versions it will remain present.
  It is recommended to use `setuptools < 60.0` for those Python versions.
  For more details, see:
    https://numpy.org/devdocs/reference/distutils_status_migration.html 


-- Looking for ccache - not found
```

Source: https://slicer.cdash.org/viewBuildError.php?buildid=2851858


Note that similar warning is also reported on `factory-south-macos` build machine.

