### PR TITLE
COMP: Update OpenCV to fix logic discovering NumPy include directory

### DIFF
--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -61,7 +61,7 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${pr
 
   ExternalProject_SetIfNotDefined(
     ${SUPERBUILD_TOPLEVEL_PROJECT}_${proj}_GIT_TAG
-    "7ab1af39429f208bf0a7affe9683bb509cdda5e9" # slicer-4.5.5-2021.12.25-dad26339a9
+    "498d4690b2331a813357d628d6a4549925033ce2" # slicer-4.5.5-2021.12.25-dad26339a9
     QUIET
     )
 
@@ -146,6 +146,8 @@ if(NOT DEFINED OpenCV_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${pr
       -DOPENCV_PYTHON_EXTRA_DEFINITIONS:STRING=CV_RELEASE_PYTHON # Specific to Slicer/opencv fork
 
       # Dependencies: Python
+      # - Options expected by the OpenCV custom CMake function "find_python()"
+      #   implemented in "cmake/OpenCVDetectPython.cmake"
       -DPYTHON3_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}
       -DPYTHON3_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DPYTHON3_LIBRARY:FILEPATH=${PYTHON_LIBRARY}


### PR DESCRIPTION
List of OpenCV changes:

```
$ git log 7ab1af394..eef3a6eee --no-merges

commit slicer/OpenCV@eef3a6eee
Author: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
Date:   Thu Nov 10 16:03:53 2022 -0500

    COMP: Fix logic discovering NumPy include directory

    This commit removes dependency on the deprecated `numpy.distutils` module
    by porting logic originally implemented in:
    - InsightSoftwareConsortium/ITKBridgeNumPy@3a8dd1f08 (ENH: Name to NumPyConversion, document module, add FindNumPy.cmake.)
    - scikit-build/skbuild/resources/cmake/FindNumPy.cmake (introduced through scikit-build/scikit-build@14dea2f50 (cmake: Add FindNumPy CMake module))
    - CMake/Modules/FindPython/Support.cmake (introduced through Kitware/CMake@513e77550 (FindPython: Introduce NumPy component))

    It addresses the following warning reported when configuring OpenCV against
    NumPy >= 1.23.

      Traceback (most recent call last):
        File "<string>", line 1, in <module>
      ImportError: No module named numpy.distutils
      -- Found PythonInterp: /work/Preview/Slicer-0-build/python-install/bin/PythonSlicer (found suitable version "3.9.10", minimum required is "3.2")
      <string>:1: DeprecationWarning:

        `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
        of the deprecation of `distutils` itself. It will be removed for
        Python >= 3.12. For older Python versions it will remain present.
        It is recommended to use `setuptools < 60.0` for those Python versions.
        For more details, see:
          https://numpy.org/devdocs/reference/distutils_status_migration.html

    See also https://numpy.org/devdocs/reference/distutils_status_migration.html

    Co-authored-by: James Butler <jamesobutler@users.noreply.github.com>
    Co-authored-by: Matt McCormick <matt.mccormick@kitware.com>
    Co-authored-by: gpersistence <gpersistence@users.noreply.github.com>
    Co-authored-by: Hiroshi Miura <miurahr@linux.com>
```